### PR TITLE
Write array lengths to match Toit output

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -491,10 +491,11 @@ type arrayEncoder struct {
 func (ae arrayEncoder) encode(e *encodeState, v reflect.Value, opts encOpts) {
 	e.WriteByte(markerArrayBegin)
 	n := v.Len()
+	e.WriteByte(markerCount)
+	writeInt(e, int64(n))
 	for i := 0; i < n; i++ {
 		ae.elemEnc(e, v.Index(i), opts)
 	}
-	e.WriteByte(markerArrayEnd)
 }
 
 func newArrayEncoder(t reflect.Type, tagName string) encoderFunc {


### PR DESCRIPTION
Trying to get the output to match the output of the Toit version
to make debugging of the patch generation easier.

This records the length of arrays at the start instead of
using a marker at the end.